### PR TITLE
Removed logs:DeleteLogDelivery permissions from CreateProfile operation

### DIFF
--- a/aws-b2bi-profile/aws-b2bi-profile.json
+++ b/aws-b2bi-profile/aws-b2bi-profile.json
@@ -116,7 +116,6 @@
         "logs:CreateLogDelivery",
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
-        "logs:DeleteLogDelivery",
         "logs:DescribeLogGroups",
         "logs:DescribeLogStreams",
         "logs:DescribeResourcePolicies",


### PR DESCRIPTION
*Description of changes:*

- Removed `logs:DeleteLogDelivery` permissions from CreateProfile operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
