### PR TITLE
Replaced "events:DescribeRule" with "events:ListRules" permission for capability resource handler

### DIFF
--- a/aws-b2bi-capability/aws-b2bi-capability.json
+++ b/aws-b2bi-capability/aws-b2bi-capability.json
@@ -226,9 +226,7 @@
       "permissions": [
         "b2bi:CreateCapability",
         "b2bi:TagResource",
-        "s3:GetObject",
-        "s3:ListBucket",
-        "events:DescribeRule",
+        "events:ListRules",
         "events:PutRule",
         "events:PutTargets",
         "logs:CreateLogDelivery",
@@ -239,7 +237,9 @@
         "logs:DescribeResourcePolicies",
         "logs:ListLogDeliveries",
         "logs:PutLogEvents",
-        "logs:PutResourcePolicy"
+        "logs:PutResourcePolicy",
+        "s3:GetObject",
+        "s3:ListBucket"
       ]
     },
     "read": {

--- a/aws-b2bi-capability/resource-role.yaml
+++ b/aws-b2bi-capability/resource-role.yaml
@@ -38,7 +38,7 @@ Resources:
                 - "b2bi:TagResource"
                 - "b2bi:UntagResource"
                 - "b2bi:UpdateCapability"
-                - "events:DescribeRule"
+                - "events:ListRules"
                 - "events:PutRule"
                 - "events:PutTargets"
                 - "logs:CreateLogDelivery"


### PR DESCRIPTION
*Description of changes:*

- Replaced `events:DescribeRule` with `events:ListRules` permission for capability resource handler.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
