### PR TITLE
Updated Lambda runtime from Java8 to Java17

### DIFF
--- a/.github/workflows/java-ci-with-maven.yml
+++ b/.github/workflows/java-ci-with-maven.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 17
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/aws-b2bi-capability/.rpdk-config
+++ b/aws-b2bi-capability/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::B2BI::Capability",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.b2bi.capability.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.b2bi.capability.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-b2bi-capability/pom.xml
+++ b/aws-b2bi-capability/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <kotlin.version>1.8.21</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -31,25 +31,31 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>b2bi</artifactId>
-            <version>2.21.32</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.20.66</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
-            <version>2.20.69</version>
+            <version>2.24.5</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
@@ -113,7 +119,7 @@
                 <plugin>
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok-maven-plugin</artifactId>
-                    <version>1.18.20.0</version>
+                    <version>1.18.22</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/aws-b2bi-capability/src/test/kotlin/software/amazon/b2bi/capability/ListHandlerTest.kt
+++ b/aws-b2bi-capability/src/test/kotlin/software/amazon/b2bi/capability/ListHandlerTest.kt
@@ -3,7 +3,6 @@ package software.amazon.b2bi.capability
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.ListCapabilitiesRequest
 import software.amazon.awssdk.services.b2bi.model.ListCapabilitiesResponse
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
@@ -28,15 +26,11 @@ class ListHandlerTest {
     private lateinit var proxy: AmazonWebServicesClientProxy
     @MockK
     private lateinit var logger: Logger
-    @MockK
-    private lateinit var b2BiClient: B2BiClient
-    private var handler = ListHandler()
+    private val handler = ListHandler()
 
     @BeforeAll
     fun setupOnce() {
         MockKAnnotations.init(this, relaxed = true)
-        mockkObject(ClientBuilder)
-        every { ClientBuilder.getClient() } returns b2BiClient
     }
 
     @AfterAll

--- a/aws-b2bi-capability/template.yml
+++ b/aws-b2bi-capability/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.capability.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-capability-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.capability.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-capability-handler-1.0-SNAPSHOT.jar
 

--- a/aws-b2bi-partnership/.rpdk-config
+++ b/aws-b2bi-partnership/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::B2BI::Partnership",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.b2bi.partnership.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.b2bi.partnership.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-b2bi-partnership/pom.xml
+++ b/aws-b2bi-partnership/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <kotlin.version>1.8.21</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -31,25 +31,31 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>b2bi</artifactId>
-            <version>2.21.32</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.20.66</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
-            <version>2.20.69</version>
+            <version>2.24.5</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
@@ -113,7 +119,7 @@
                 <plugin>
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok-maven-plugin</artifactId>
-                    <version>1.18.20.0</version>
+                    <version>1.18.22</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/aws-b2bi-partnership/src/test/kotlin/software/amazon/b2bi/partnership/ListHandlerTest.kt
+++ b/aws-b2bi-partnership/src/test/kotlin/software/amazon/b2bi/partnership/ListHandlerTest.kt
@@ -3,7 +3,6 @@ package software.amazon.b2bi.partnership
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.ListPartnershipsRequest
 import software.amazon.awssdk.services.b2bi.model.ListPartnershipsResponse
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
@@ -28,15 +26,11 @@ class ListHandlerTest {
     private lateinit var proxy: AmazonWebServicesClientProxy
     @MockK
     private lateinit var logger: Logger
-    @MockK
-    private lateinit var b2BiClient: B2BiClient
-    private var handler = ListHandler()
+    private val handler = ListHandler()
 
     @BeforeAll
     fun setupOnce() {
         MockKAnnotations.init(this, relaxed = true)
-        mockkObject(ClientBuilder)
-        every { ClientBuilder.getClient() } returns b2BiClient
     }
 
     @AfterAll

--- a/aws-b2bi-partnership/template.yml
+++ b/aws-b2bi-partnership/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.partnership.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-partnership-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.partnership.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-partnership-handler-1.0-SNAPSHOT.jar
 

--- a/aws-b2bi-profile/.rpdk-config
+++ b/aws-b2bi-profile/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::B2BI::Profile",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.b2bi.profile.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.b2bi.profile.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-b2bi-profile/pom.xml
+++ b/aws-b2bi-profile/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <kotlin.version>1.8.21</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -31,25 +31,31 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>b2bi</artifactId>
-            <version>2.21.32</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.20.66</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
-            <version>2.20.69</version>
+            <version>2.24.5</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
@@ -113,7 +119,7 @@
                 <plugin>
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok-maven-plugin</artifactId>
-                    <version>1.18.20.0</version>
+                    <version>1.18.22</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/aws-b2bi-profile/src/test/kotlin/software/amazon/b2bi/profile/ListHandlerTest.kt
+++ b/aws-b2bi-profile/src/test/kotlin/software/amazon/b2bi/profile/ListHandlerTest.kt
@@ -3,7 +3,6 @@ package software.amazon.b2bi.profile
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.ListProfilesRequest
 import software.amazon.awssdk.services.b2bi.model.ListProfilesResponse
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
@@ -28,15 +26,11 @@ class ListHandlerTest {
     private lateinit var proxy: AmazonWebServicesClientProxy
     @MockK
     private lateinit var logger: Logger
-    @MockK
-    private lateinit var b2BiClient: B2BiClient
-    private var handler = ListHandler()
+    private val handler = ListHandler()
 
     @BeforeAll
     fun setupOnce() {
         MockKAnnotations.init(this, relaxed = true)
-        mockkObject(ClientBuilder)
-        every { ClientBuilder.getClient() } returns b2BiClient
     }
 
     @AfterAll

--- a/aws-b2bi-profile/template.yml
+++ b/aws-b2bi-profile/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.profile.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-profile-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.profile.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-profile-handler-1.0-SNAPSHOT.jar
 

--- a/aws-b2bi-transformer/.rpdk-config
+++ b/aws-b2bi-transformer/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::B2BI::Transformer",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.b2bi.transformer.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.b2bi.transformer.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-b2bi-transformer/pom.xml
+++ b/aws-b2bi-transformer/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <kotlin.version>1.8.21</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -31,25 +31,31 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>b2bi</artifactId>
-            <version>2.21.32</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.20.66</version>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-core -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
-            <version>2.20.69</version>
+            <version>2.24.5</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.24.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
@@ -105,18 +111,6 @@
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.6.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.6.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -125,7 +119,7 @@
                 <plugin>
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok-maven-plugin</artifactId>
-                    <version>1.18.20.0</version>
+                    <version>1.18.22</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/CreateHandlerTest.kt
+++ b/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/CreateHandlerTest.kt
@@ -6,23 +6,25 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.mockito.junit.jupiter.MockitoExtension
 import software.amazon.awssdk.awscore.exception.AwsServiceException
-import software.amazon.awssdk.core.SdkClient
 import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.CreateTransformerRequest
 import software.amazon.awssdk.services.b2bi.model.CreateTransformerResponse
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException
-import software.amazon.cloudformation.proxy.*
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
+import software.amazon.cloudformation.proxy.OperationStatus
+import software.amazon.cloudformation.proxy.ProgressEvent
+import software.amazon.cloudformation.proxy.ProxyClient
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest
 import java.time.Duration
-import java.util.function.Supplier
 
 @TestInstance(Lifecycle.PER_CLASS)
 class CreateHandlerTest : AbstractTestBase() {

--- a/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/DeleteHandlerTest.kt
+++ b/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/DeleteHandlerTest.kt
@@ -5,22 +5,25 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.mockito.junit.jupiter.MockitoExtension
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
 import software.amazon.awssdk.awscore.exception.AwsServiceException
-import software.amazon.awssdk.core.SdkClient
 import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.DeleteTransformerRequest
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException
-import software.amazon.cloudformation.proxy.*
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
+import software.amazon.cloudformation.proxy.OperationStatus
+import software.amazon.cloudformation.proxy.ProgressEvent
+import software.amazon.cloudformation.proxy.ProxyClient
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest
 import java.time.Duration
-import java.util.function.Supplier
-import org.assertj.core.api.Assertions.assertThatThrownBy
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class DeleteHandlerTest : AbstractTestBase() {
     private lateinit var proxy: AmazonWebServicesClientProxy
     private lateinit var b2BiClient: B2BiClient
@@ -34,6 +37,7 @@ class DeleteHandlerTest : AbstractTestBase() {
         proxyClient = mockProxy(proxy, b2BiClient)
     }
 
+    @AfterEach
     fun reset() {
         clearAllMocks()
     }

--- a/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/ListHandlerTest.kt
+++ b/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/ListHandlerTest.kt
@@ -3,39 +3,34 @@ package software.amazon.b2bi.transformer
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockkObject
 import io.mockk.unmockkAll
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mock
-import org.mockito.Mockito.mock
-import org.mockito.junit.jupiter.MockitoExtension
-import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.ListTransformersRequest
 import software.amazon.awssdk.services.b2bi.model.ListTransformersResponse
-import software.amazon.cloudformation.proxy.*
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
+import software.amazon.cloudformation.proxy.Logger
+import software.amazon.cloudformation.proxy.OperationStatus
+import software.amazon.cloudformation.proxy.ProgressEvent
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest
 import java.util.function.Function
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class ListHandlerTest {
     @MockK
     private lateinit var proxy: AmazonWebServicesClientProxy
-
     @MockK
     private lateinit var logger: Logger
-    @MockK
-    private lateinit var b2BiClient: B2BiClient
-    private var handler = ListHandler()
+    private val handler = ListHandler()
 
     @BeforeAll
     fun setupOnce() {
         MockKAnnotations.init(this, relaxed = true)
-        mockkObject(ClientBuilder)
-        every { ClientBuilder.getClient() } returns b2BiClient
     }
 
     @AfterAll

--- a/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/ReadHandlerTest.kt
+++ b/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/ReadHandlerTest.kt
@@ -6,26 +6,29 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.mockito.junit.jupiter.MockitoExtension
 import software.amazon.awssdk.awscore.exception.AwsServiceException
-import software.amazon.awssdk.core.SdkClient
 import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.GetTransformerRequest
 import software.amazon.awssdk.services.b2bi.model.GetTransformerResponse
 import software.amazon.awssdk.services.b2bi.model.ListTagsForResourceRequest
 import software.amazon.awssdk.services.b2bi.model.ListTagsForResourceResponse
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException
-import software.amazon.cloudformation.proxy.*
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
+import software.amazon.cloudformation.proxy.OperationStatus
+import software.amazon.cloudformation.proxy.ProgressEvent
+import software.amazon.cloudformation.proxy.ProxyClient
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest
 import java.time.Duration
-import java.util.function.Supplier
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class ReadHandlerTest : AbstractTestBase() {
     private lateinit var proxy: AmazonWebServicesClientProxy
     private lateinit var b2BiClient: B2BiClient

--- a/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/UpdateHandlerTest.kt
+++ b/aws-b2bi-transformer/src/test/kotlin/software/amazon/b2bi/transformer/UpdateHandlerTest.kt
@@ -5,22 +5,24 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.mockito.junit.jupiter.MockitoExtension
-import software.amazon.awssdk.core.SdkClient
 import software.amazon.awssdk.services.b2bi.B2BiClient
 import software.amazon.awssdk.services.b2bi.model.UpdateTransformerRequest
 import software.amazon.awssdk.services.b2bi.model.UpdateTransformerResponse
-import software.amazon.cloudformation.proxy.*
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy
+import software.amazon.cloudformation.proxy.OperationStatus
+import software.amazon.cloudformation.proxy.ProgressEvent
+import software.amazon.cloudformation.proxy.ProxyClient
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest
 import java.time.Duration
-import java.util.function.Supplier
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_CLASS)
 class UpdateHandlerTest : AbstractTestBase() {
     private lateinit var proxy: AmazonWebServicesClientProxy
     private lateinit var b2BiClient: B2BiClient

--- a/aws-b2bi-transformer/template.yml
+++ b/aws-b2bi-transformer/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.transformer.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-transformer-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.b2bi.transformer.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-b2bi-transformer-handler-1.0-SNAPSHOT.jar
 


### PR DESCRIPTION
*Description of changes:*

For all `AWS::B2BI::*` resources, the following changes were made:

- Up Lambda runtime from Java8 to Java17.
- Updated/added Maven dependecies:
  - All `software.amazon.awssdk` dependencies updated to version 2.24.5.
  - Added `software.amazon.awssdk:utils:2.24.5` dependency.
  - Updated Lombok version to `1.18.22`.
- Fixed unit test issues that arose from dependency updates.
- Updated GitHub action to checkout Java17.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
